### PR TITLE
Support a 30min trigger schedule but only rotate keys every 7 days.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -71,13 +71,13 @@ func New(manager *Manager, tokenTemplate, keyTemplate, titleTemplate string, log
 					description, err := manager.describeSecret(keyPath)
 					if err != nil {
 						log.Warnf("failed to describe secret: %s", err)
-						continue Loop
+						break
 					}
 
 					updated, err := parseUpdatedDate(description)
 					if err != nil {
 						log.Warnf("failed to parse updated date: %s", err)
-						continue Loop
+						break
 					}
 
 					if updated.After(time.Now().AddDate(0, 0, -7)) {
@@ -120,7 +120,7 @@ func New(manager *Manager, tokenTemplate, keyTemplate, titleTemplate string, log
 }
 
 func parseUpdatedDate(description string) (*time.Time, error) {
-	r, err := regexp.Compile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)
+	r, err := regexp.Compile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|[+-]{1}\d{2}:\d{2})`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile regexp: %s", err)
 	}

--- a/handler.go
+++ b/handler.go
@@ -64,7 +64,11 @@ func New(manager *Manager, tokenTemplate, keyTemplate, titleTemplate string, log
 				if *key.Title == title {
 					oldKey = key
 
-					// Make sure the deploy key is old enough to need rotating
+					// Rotate the key if read/write permissions have changed
+					if key.ReadOnly != nil && *key.ReadOnly != bool(repository.ReadOnly) {
+						break
+					}
+					// Do not rotate if nothing has changed and the key is not >7 days old
 					updated, err := manager.describeSecret(keyPath)
 					if err != nil {
 						log.Warnf("failed to describe secret: %s", err)

--- a/handler_test.go
+++ b/handler_test.go
@@ -80,6 +80,24 @@ func TestHandler(t *testing.T) {
 				KeyMaterial: aws.String(keyMaterial),
 			},
 		},
+		{
+			description: "rotates if timestamp cannot be parsed",
+			tokenPath:   "/concourse/{{.Team}}/{{.Owner}}",
+			keyPath:     "/concourse/{{.Team}}/{{.Repository}}",
+			keyTitle:    "concourse-{{.Team}}-deploy-key",
+			team:        team,
+			githubKeys: []*github.Key{
+				{
+					ID:    github.Int64(1),
+					Title: github.String("concourse-test-team-deploy-key"),
+				},
+			},
+			lastUpdated:  "nil",
+			shouldRotate: true,
+			createdKey: &ec2.CreateKeyPairOutput{
+				KeyMaterial: aws.String(keyMaterial),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,7 +1,11 @@
 package handler_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -29,13 +33,15 @@ func TestHandler(t *testing.T) {
 	}
 
 	tests := []struct {
-		description string
-		tokenPath   string
-		keyPath     string
-		keyTitle    string
-		team        handler.Team
-		githubKeys  []*github.Key
-		createdKey  *ec2.CreateKeyPairOutput
+		description  string
+		tokenPath    string
+		keyPath      string
+		keyTitle     string
+		team         handler.Team
+		githubKeys   []*github.Key
+		lastUpdated  string
+		shouldRotate bool
+		createdKey   *ec2.CreateKeyPairOutput
 	}{
 
 		{
@@ -50,6 +56,26 @@ func TestHandler(t *testing.T) {
 					Title: github.String("concourse-test-team-deploy-key"),
 				},
 			},
+			lastUpdated:  "2018-01-01T01:01:01Z",
+			shouldRotate: true,
+			createdKey: &ec2.CreateKeyPairOutput{
+				KeyMaterial: aws.String(keyMaterial),
+			},
+		},
+		{
+			description: "does not rotate keys if they have recently been updated",
+			tokenPath:   "/concourse/{{.Team}}/{{.Owner}}",
+			keyPath:     "/concourse/{{.Team}}/{{.Repository}}",
+			keyTitle:    "concourse-{{.Team}}-deploy-key",
+			team:        team,
+			githubKeys: []*github.Key{
+				{
+					ID:    github.Int64(1),
+					Title: github.String("concourse-test-team-deploy-key"),
+				},
+			},
+			lastUpdated:  time.Now().Format(time.RFC3339),
+			shouldRotate: false,
 			createdKey: &ec2.CreateKeyPairOutput{
 				KeyMaterial: aws.String(keyMaterial),
 			},
@@ -63,17 +89,23 @@ func TestHandler(t *testing.T) {
 
 			repos := mocks.NewMockRepoClient(ctrl)
 			repos.EXPECT().ListKeys(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(tc.githubKeys, nil, nil)
-			repos.EXPECT().CreateKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, nil, nil)
-			repos.EXPECT().DeleteKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
+			if tc.shouldRotate {
+				repos.EXPECT().CreateKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, nil, nil)
+				repos.EXPECT().DeleteKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
+			}
 
 			apps := mocks.NewMockAppsClient(ctrl)
 			apps.EXPECT().CreateInstallationToken(gomock.Any(), gomock.Any()).Times(1).Return(&github.InstallationToken{Token: github.String("token")}, nil, nil)
 
 			ec2 := mocks.NewMockEC2Client(ctrl)
-			ec2.EXPECT().CreateKeyPair(gomock.Any()).Times(1).Return(tc.createdKey, nil)
-			ec2.EXPECT().DeleteKeyPair(gomock.Any()).Times(1)
+			if tc.shouldRotate {
+				ec2.EXPECT().CreateKeyPair(gomock.Any()).Times(1).Return(tc.createdKey, nil)
+				ec2.EXPECT().DeleteKeyPair(gomock.Any()).Times(1)
+			}
 
 			secrets := mocks.NewMockSecretsClient(ctrl)
+			description := &secretsmanager.DescribeSecretOutput{Description: aws.String(fmt.Sprintf("Github credentials for Concourse. Last updated: %s", tc.lastUpdated))}
+			secrets.EXPECT().DescribeSecret(gomock.Any()).MinTimes(1).Return(description, nil)
 			secrets.EXPECT().CreateSecret(gomock.Any()).MinTimes(1).Return(nil, nil)
 			secrets.EXPECT().UpdateSecret(gomock.Any()).MinTimes(1).Return(nil, nil)
 

--- a/manager.go
+++ b/manager.go
@@ -128,12 +128,24 @@ func (m *Manager) deleteKey(repository Repository, id int) error {
 }
 
 // Write a secret to secrets manager.
+func (m *Manager) describeSecret(name string) (string, error) {
+	out, err := m.secretsClient.DescribeSecret(&secretsmanager.DescribeSecretInput{
+		SecretId: aws.String(name),
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.StringValue(out.Description), nil
+}
+
+// Write a secret to secrets manager.
 func (m *Manager) writeSecret(name, secret string) error {
 	var err error
+	timestamp := time.Now().Format(time.RFC3339)
 
 	_, err = m.secretsClient.CreateSecret(&secretsmanager.CreateSecretInput{
 		Name:        aws.String(name),
-		Description: aws.String("Github deploy key for Concourse."),
+		Description: aws.String(fmt.Sprintf("Github credentials for Concourse. Last updated: %s", timestamp)),
 	})
 	if err != nil {
 		e, ok := err.(awserr.Error)
@@ -144,8 +156,6 @@ func (m *Manager) writeSecret(name, secret string) error {
 			return err
 		}
 	}
-
-	timestamp := time.Now().Format(time.RFC3339)
 
 	_, err = m.secretsClient.UpdateSecret(&secretsmanager.UpdateSecretInput{
 		Description:  aws.String(fmt.Sprintf("Github credentials for Concourse. Last updated: %s", timestamp)),

--- a/manager.go
+++ b/manager.go
@@ -128,14 +128,14 @@ func (m *Manager) deleteKey(repository Repository, id int) error {
 }
 
 // Write a secret to secrets manager.
-func (m *Manager) describeSecret(name string) (string, error) {
+func (m *Manager) describeSecret(name string) (*time.Time, error) {
 	out, err := m.secretsClient.DescribeSecret(&secretsmanager.DescribeSecretInput{
 		SecretId: aws.String(name),
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return aws.StringValue(out.Description), nil
+	return out.LastChangedDate, nil
 }
 
 // Write a secret to secrets manager.

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -64,6 +64,7 @@ data "aws_iam_policy_document" "lambda" {
     actions = [
       "secretsmanager:CreateSecret",
       "secretsmanager:UpdateSecret",
+      "secretsmanager:DescribeSecret",
     ]
 
     resources = [

--- a/terraform/modules/trigger/main.tf
+++ b/terraform/modules/trigger/main.tf
@@ -4,7 +4,7 @@
 resource "aws_cloudwatch_event_rule" "main" {
   name                = "${var.name_prefix}-github-${substr(md5(var.team_config), 0, 7)}"
   description         = "Github Lambda team configuration and trigger."
-  schedule_expression = "rate(7 days)"
+  schedule_expression = "rate(30 min)"
 }
 
 resource "aws_cloudwatch_event_target" "main" {


### PR DESCRIPTION
According to https://developer.github.com/v3/apps/#create-a-new-installation-token, tokens expire after 1h - the Lambda should exchange them every 30min to ensure that they always have 30min left until expiry. However, we don't want to rotate the deploy keys this frequently, so I'll need to adjust the code as well.