### PR TITLE
Fix invalid credentials error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 notifications:
   email: false
 script:
-- make release
+- make test && make release
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ matrix:
     env:
     - TARGET=linux
     - ARCH=amd64
+before_install:
+  - curl -fSL "https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip" -o terraform.zip
+  - sudo unzip terraform.zip -d /opt/terraform
+  - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+  - rm -f terraform.zip
 notifications:
   email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 notifications:
   email: false
 script:
-- make test && make release
+- make release && make test
 deploy:
   provider: releases
   api_key:

--- a/apps.go
+++ b/apps.go
@@ -74,7 +74,7 @@ func (a *GithubApp) getInstallationClient(owner string) (client *GithubClient, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to get installation token: %s", err)
 		}
-		oauth := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		oauth := oauth2.NewClient(context.TODO(), oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		))
 		client := github.NewClient(oauth)

--- a/apps.go
+++ b/apps.go
@@ -19,7 +19,7 @@ type GithubClient struct {
 	Apps       AppsClient
 }
 
-func (c *GithubClient) expired() bool {
+func (c *GithubClient) isExpired() bool {
 	return c.Expiration.Before(time.Now())
 }
 
@@ -75,7 +75,7 @@ func (a *GithubApp) createInstallationToken(owner string) (token string, expirat
 
 func (a *GithubApp) getInstallationClient(owner string) (client *GithubClient, err error) {
 	owner = strings.ToLower(owner)
-	if c, ok := a.Clients[owner]; !ok || c.expired() {
+	if c, ok := a.Clients[owner]; !ok || c.isExpired() {
 		token, expiration, err := a.createInstallationToken(owner)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get installation token: %s", err)

--- a/apps.go
+++ b/apps.go
@@ -20,7 +20,7 @@ type GithubClient struct {
 }
 
 func (c *GithubClient) isExpired() bool {
-	return c.Expiration.Before(time.Now())
+	return c.Expiration.Before(time.Now().Add(1 * time.Minute))
 }
 
 // GithubApp ...

--- a/apps.go
+++ b/apps.go
@@ -74,7 +74,7 @@ func (a *GithubApp) getInstallationClient(owner string) (client *GithubClient, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to get installation token: %s", err)
 		}
-		oauth := oauth2.NewClient(context.TODO(), oauth2.StaticTokenSource(
+		oauth := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		))
 		client := github.NewClient(oauth)

--- a/apps.go
+++ b/apps.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/google/go-github/github"
@@ -13,8 +14,13 @@ import (
 
 // GithubClient ...
 type GithubClient struct {
-	Repos RepoClient
-	Apps  AppsClient
+	Expiration time.Time
+	Repos      RepoClient
+	Apps       AppsClient
+}
+
+func (c *GithubClient) expired() bool {
+	return c.Expiration.Before(time.Now())
 }
 
 // GithubApp ...
@@ -53,24 +59,24 @@ func newGithubApp(integrationID int, privateKey string) (*GithubApp, error) {
 	}, nil
 }
 
-func (a *GithubApp) createInstallationToken(owner string) (token string, err error) {
+func (a *GithubApp) createInstallationToken(owner string) (token string, expiration time.Time, err error) {
 	owner = strings.ToLower(owner)
 	id, ok := a.Installations[owner]
 	if !ok {
-		return token, fmt.Errorf("the deploy key app is not installed for user or org: '%s'", owner)
+		return token, expiration, fmt.Errorf("the deploy key app is not installed for user or org: '%s'", owner)
 	}
 	installationToken, _, err := a.App.CreateInstallationToken(context.TODO(), id)
 	if err != nil {
-		return token, fmt.Errorf("failed to create token: %s", err)
+		return token, expiration, fmt.Errorf("failed to create token: %s", err)
 	}
-	token = installationToken.GetToken()
-	return token, nil
+	token, expiration = installationToken.GetToken(), installationToken.GetExpiresAt()
+	return token, expiration, nil
 }
 
 func (a *GithubApp) getInstallationClient(owner string) (client *GithubClient, err error) {
 	owner = strings.ToLower(owner)
-	if _, ok := a.Clients[owner]; !ok {
-		token, err := a.createInstallationToken(owner)
+	if c, ok := a.Clients[owner]; !ok || c.expired() {
+		token, expiration, err := a.createInstallationToken(owner)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get installation token: %s", err)
 		}
@@ -79,8 +85,9 @@ func (a *GithubApp) getInstallationClient(owner string) (client *GithubClient, e
 		))
 		client := github.NewClient(oauth)
 		a.Clients[owner] = &GithubClient{
-			Repos: client.Repositories,
-			Apps:  client.Apps,
+			Repos:      client.Repositories,
+			Apps:       client.Apps,
+			Expiration: expiration,
 		}
 	}
 	client, _ = a.Clients[owner]

--- a/handler_test.go
+++ b/handler_test.go
@@ -138,8 +138,9 @@ func TestHandler(t *testing.T) {
 				Installations: map[string]int64{tc.team.Repositories[0].Owner: 1},
 				Clients:       map[string]*handler.GithubClient{tc.team.Repositories[0].Owner: {Apps: apps, Repos: repos, Expiration: tc.clientExpiration}},
 			}
+			manager := handler.NewTestManager(secrets, ec2, services, services)
 			logger, _ := logrus.NewNullLogger()
-			handle := handler.New(handler.NewTestManager(secrets, ec2, services, services), tc.tokenPath, tc.keyPath, tc.keyTitle, logger)
+			handle := handler.New(manager, tc.tokenPath, tc.keyPath, tc.keyTitle, logger)
 
 			if err := handle(tc.team); err != nil {
 				t.Fatalf("unexpected error: %s", err)

--- a/manager.go
+++ b/manager.go
@@ -83,7 +83,8 @@ func NewManager(
 
 // Create an access token for the organisation
 func (m *Manager) createAccessToken(owner string) (string, error) {
-	return m.tokenService.createInstallationToken(owner)
+	token, _, err := m.tokenService.createInstallationToken(owner)
+	return token, err
 }
 
 // List deploy keys for a repository


### PR DESCRIPTION
This fixes a problem where `listKeys` responded with `401 Bad credentials`. However, I can't really explain WHY it fixes the problem.

According to the docs:
https://golang.org/pkg/context/#Background

`context.Background()` _"is never canceled, has no values, and has no deadline"_. However, it seems like it was somehow cancelled since Github stopped responding with 401 after I changed to `context.TODO()`.

According to the oauth2 docs:
https://godoc.org/golang.org/x/oauth2

You should be able to use either `context.Background()` or `context.TODO()` if you are not passing an actual context in. Not sure whats up here.