### PR TITLE
Use last updated from secret description instead of lastchanged from SM

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -71,14 +71,13 @@ func New(manager *Manager, tokenTemplate, keyTemplate, titleTemplate string, log
 						break
 					}
 					// Do not rotate if nothing has changed and the key is not >7 days old
-					updated, err := manager.getLastChanged(keyPath)
+					updated, err := manager.getLastUpdated(keyPath)
 					if err != nil {
-						if e, ok := err.(awserr.Error); ok {
-							if e.Code() != secretsmanager.ErrCodeResourceNotFoundException {
-								// Do not log a warning if we fail to describe because the secret does not exist.
-								log.Warnf("failed to describe secret: %s", err)
-							}
+						if e, ok := err.(awserr.Error); ok && e.Code() == secretsmanager.ErrCodeResourceNotFoundException {
+							// Do not log a warning if we fail to describe because the secret does not exist.
+							break
 						}
+						log.Warnf("failed to get last updated for secret: %s", err)
 						break
 					}
 					if updated.After(time.Now().AddDate(0, 0, -7)) {


### PR DESCRIPTION
Seemingly, the `LastChangeDate` returned from `DescribeSecret` in the Secrets Manager API is usually updated daily at 0100 UTC (in eu-west-1) by some event which is not logged to CloudTrail. I suspect this is some internal working at AWS (e.g. rotating the master key), and have filed an issue to get confirmation if this is working as intended.

Assuming that this is working as intended, this PR switches over to parsing the last update date from the secret description (which is put there in the first place by this lambda). As part of the PR I also improved the following:

- Tests should fail if warnings/errors/panics are logged by the handler.
- An if-statement in the handler which meant that non-AWS errors were not being logged (the intention was to not log `ResourceNotFound` errors).
- Only use UTC time for the Last updated time which is written to the secret description (which means that the RFC3339 formatted time will end with a `Z` for UTC, and we can have a simpler regexp).