### PR TITLE
Generate deploy keys locally

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -8,15 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/github"
 	logrus "github.com/sirupsen/logrus/hooks/test"
 	"github.com/telia-oss/concourse-github-lambda"
 	"github.com/telia-oss/concourse-github-lambda/mocks"
 )
-
-const keyMaterial = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAm9RgNyONxqSQHGhMk05iRxHSZ1PKxAPBioDjvzBwNyEVifGmiSmqcoeXgLQU\nQzFSTVgffLkPjndHvMrq+Shq0eSwsulSvyR5B+cL+ob7XPMkzO+2vmNAVfcBbG7jJ7kqdwP0KH3g\nZZ1+dgRfxSR/ziWRf0iiILc7mfPPrQ2W8MAfokS4kmw5OpvYlug05gje76CZtMR+/Ium7En+Ul/j\n8TuoahQno9LkxiXl8huEBM3VO6wQ7IAHvQHhoXb6w4pBFybgA3p3ZftSsY2LZHLAmXNxwzSMNACC\n+Q/Z1XejGNamjebSI3fgWghg6aAlvD6qjyx7AUEr+dbsHeHTaZzoIQIDAQABAoIBAQCCxeUFAQJf\nHQWPwXvZ92MEj5FKg4hbnWdT67y1W1og+dPQkwqWe2/+c4oSSY3jocWXAQhTrB7BCZsbdhNhi6ix\ngsFDNAnsPRiRKDXmRlc2dxqAHf/3oOWB/yujqx9Y280mWhwRyymBPX2+XwdcM7hJ8T88WWEuIXeU\nSIcVjJ0KZnFFmlQ0lm4bLR6nxccJROGhmYlhzxZCi+OroLjCA0usOhOPMiOxs71BQxSb4PyKiL0V\n1pgpat5UdG2pGZXoiYxmU5YWRv/IoOvvBjaE7vACJJEBiIv7T4yX1n6TrRvtHhI4fVkguGHkdf0C\nEbu55AUe17ga2aAfHfGBf48aznEdAoGBANbTyVlsEEgJkme5kElgmmCkkqTQy/HAApKDuX/WsecF\nFS4A3zw5mcde7NsW8dXcc+2EwZtE99+Wl1PhR8vSomV+K5tkNLUb+PFtEIDtIsIaczxzCuDyMDcY\nPyQ/VrUC5arE2M9sr5do/AqsxzlCZLEL7Uaqt2j+YR9TAvPLQ3NfAoGBALmx8jzkZAm5KRV2T6ng\nctm8XbWI5D5EiTyp+C74JOpNL8F+xeSpa/GQ3vKvTwu0NlOwn9FkePOKu+Nf9T9E1yvW3ppY3Iuf\nSJLlPEO3oyiewISskr6ueAf17tPXOtD3HR3+idbp4heNUsOOWeP5Rey+5F6dB3Nk2ZjUrXdp5NR/\nAoGBAJHKUM7642G//TefWygxAxOrHEn12TJLGHPOKUl0rm8Vp/X8aYM5o/8FkMBupdh5L8N1YN66\nw21diX1HWa4dWFCAe5+NNafjP+K4HYchZ4FK6gGQIUXflpENR2yV/4YAXVSzGmBKZi/e841bDCjz\nwdnVOkXG/YmneMoFT++bdj8JAoGBAJ+zfVyHI84E82Nk4/B6euvthz434+v1b32/xBVJDh5/kYG8\n8J7OYmpXqJZY1QeAznQ9Y8Vmvmrdtuc+wKHQJ6mpWrqtj8d4jqbfBWxLw8OMfI/eBzp8u/hEt0hz\nQz8yN1VzcsJlVS/iN/q9M2vQFyYbqjYAoMbKRiWdSy524PkrAoGAEOp+uT0mUy9c6T8Pk3I+ASZb\njCh03+/v87AFdInVNETZNJuR6IaoRW44+n9+3ClrbWFz+PJYisNHrsTqtMxKDDIjIaTohxjhNQGP\nsm53ZjEVsGPT+9NI8QZvbHVMB5lGFqD1riihTBlZms3YjKmPv6Z7svnh8w1R5tDhZ001Yjw=\n-----END RSA PRIVATE KEY-----"
 
 func TestHandler(t *testing.T) {
 	owner := "telia-oss"
@@ -41,7 +38,6 @@ func TestHandler(t *testing.T) {
 		existingKey       *github.Key
 		secretLastUpdated string
 		shouldRotate      bool
-		createdKey        *ec2.CreateKeyPairOutput
 	}{
 
 		{
@@ -57,9 +53,6 @@ func TestHandler(t *testing.T) {
 			},
 			secretLastUpdated: time.Now().AddDate(0, 0, -10).UTC().Format(time.RFC3339),
 			shouldRotate:      true,
-			createdKey: &ec2.CreateKeyPairOutput{
-				KeyMaterial: aws.String(keyMaterial),
-			},
 		},
 		{
 			description: "does not rotate keys if they have recently been updated",
@@ -73,9 +66,6 @@ func TestHandler(t *testing.T) {
 				ReadOnly: github.Bool(true),
 			},
 			secretLastUpdated: time.Now().UTC().Format(time.RFC3339),
-			createdKey: &ec2.CreateKeyPairOutput{
-				KeyMaterial: aws.String(keyMaterial),
-			},
 		},
 		{
 			description: "rotates recently updated keys if the desired permissions have changed",
@@ -90,9 +80,6 @@ func TestHandler(t *testing.T) {
 			},
 			secretLastUpdated: time.Now().UTC().Format(time.RFC3339),
 			shouldRotate:      true,
-			createdKey: &ec2.CreateKeyPairOutput{
-				KeyMaterial: aws.String(keyMaterial),
-			},
 		},
 	}
 
@@ -112,12 +99,6 @@ func TestHandler(t *testing.T) {
 			if tc.shouldRotate {
 				repos.EXPECT().CreateKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, nil, nil)
 				repos.EXPECT().DeleteKey(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
-			}
-
-			ec2 := mocks.NewMockEC2Client(ctrl)
-			if tc.shouldRotate {
-				ec2.EXPECT().CreateKeyPair(gomock.Any()).Times(1).Return(tc.createdKey, nil)
-				ec2.EXPECT().DeleteKeyPair(gomock.Any()).Times(1)
 			}
 
 			secrets := mocks.NewMockSecretsClient(ctrl)
@@ -142,7 +123,7 @@ func TestHandler(t *testing.T) {
 					},
 				},
 			}
-			manager := handler.NewTestManager(secrets, ec2, services, services)
+			manager := handler.NewTestManager(secrets, services, services)
 			logger, hook := logrus.NewNullLogger()
 			handle := handler.New(manager, tc.tokenPath, tc.keyPath, tc.keyTitle, logger)
 


### PR DESCRIPTION
This generates the SSH deploy keys locally using the `crypto/rsa` package. I'm not sure if there was a reason to use the EC2 API to generate them, but this is required if we want to make this work outside of AWS (see #28) 