### PR TITLE
sanitise github repo names for concourse param usage

### DIFF
--- a/models.go
+++ b/models.go
@@ -24,7 +24,7 @@ func NewTemplate(team, repository, owner, template string) *Template {
 		Team:  team,
 		Owner: owner,
 		// sanitise the secrets manager path as concourse treats dots as delimiters
-		Repository: strings.Replace(repository, ".", "-", -1),
+		Repository: strings.ReplaceAll(repository, ".", "-"),
 		Template:   template,
 	}
 }

--- a/models.go
+++ b/models.go
@@ -21,9 +21,10 @@ type Repository struct {
 // NewTemplate for github key title and secrets manager path.
 func NewTemplate(team, repository, owner, template string) *Template {
 	return &Template{
-		Team:       team,
-		Owner:      owner,
-		Repository: repository,
+		Team:  team,
+		Owner: owner,
+		// sanitise the secrets manager path as concourse treats dots as delimiters
+		Repository: strings.Replace(repository, ".", "-", -1),
 		Template:   template,
 	}
 }


### PR DESCRIPTION
Currently if your github repositories have dots in them, you cannot access the secrets created via parameters in concourse.
Concourse [treats dots as delimiters](https://github.com/concourse/concourse/blob/f3f2dc13519898f12017f337159f413060fb0cd3/vars/template.go#L142), so we should avoid using them and replace them with a dash instead.
Can you cut a new release and upload to your s3 bucket too please?