### PR TITLE
Prepare new v1.2.0 release

### DIFF
--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   s3_bucket = var.filename == null && var.s3_bucket == null ? "telia-oss-${data.aws_region.current.name}" : var.s3_bucket
-  s3_key    = var.filename == null && var.s3_key == null ? "concourse-github-lambda/v1.0.0.zip" : var.s3_key
+  s3_key    = var.filename == null && var.s3_key == null ? "concourse-github-lambda/v1.2.0.zip" : var.s3_key
 }
 
 module "lambda" {


### PR DESCRIPTION
Related to #35 and #34: This sets the default version in terraform to what is intended to be the next release (`v1.2.0`).