### PR TITLE
Use statement prefix IDs for lambda permissions

### DIFF
--- a/terraform/modules/team/main.tf
+++ b/terraform/modules/team/main.tf
@@ -15,11 +15,11 @@ resource "aws_cloudwatch_event_target" "main" {
 }
 
 resource "aws_lambda_permission" "main" {
-  statement_id  = "concourse-${var.name}-github-lambda-permission"
-  action        = "lambda:InvokeFunction"
-  function_name = var.lambda_arn
-  principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.main.arn
+  statement_id_prefix = "concourse-${var.name}-github-lambda-permission-"
+  action              = "lambda:InvokeFunction"
+  function_name       = var.lambda_arn
+  principal           = "events.amazonaws.com"
+  source_arn          = aws_cloudwatch_event_rule.main.arn
 }
 
 locals {

--- a/terraform/modules/team/main.tf
+++ b/terraform/modules/team/main.tf
@@ -15,7 +15,8 @@ resource "aws_cloudwatch_event_target" "main" {
 }
 
 resource "aws_lambda_permission" "main" {
-  statement_id_prefix = "concourse-${var.name}-github-lambda-permission-"
+  statement_id        = var.use_statement_id_prefix ? null : "concourse-${var.name}-github-lambda-permission"
+  statement_id_prefix = var.use_statement_id_prefix ? "concourse-${var.name}-github-lambda-permission-" : null
   action              = "lambda:InvokeFunction"
   function_name       = var.lambda_arn
   principal           = "events.amazonaws.com"

--- a/terraform/modules/team/variables.tf
+++ b/terraform/modules/team/variables.tf
@@ -6,6 +6,12 @@ variable "name" {
   type        = string
 }
 
+variable "use_statement_id_prefix" {
+  description = "If the name is used as a prefix to a randomised name or not"
+  type        = bool
+  default     = false
+}
+
 variable "lambda_arn" {
   description = "ARN of the Github Lambda."
   type        = string


### PR DESCRIPTION
We had an issue where the JSON blob for the CloudWatch events config was >8192 bytes causing CloudWatch to reject the change.

To get around this we used this module multiple times with the same team name with a smaller list of repositories.

We got a name collision on the Lambda permissions. To resolve this we would like to use prefixes.